### PR TITLE
Update role to perform tasks regardless of the `maxmind_license_key` variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,75 +6,71 @@
       - gzip
       - tar
 
-# Download and extract the MaxMind GeoIP2 database.
-- name: Check the GeoIP database and replace if it is out of date
-  when: geoip2_maxmind_license_key | default(false)
+- name: Set the full path for saving the database locally
+  ansible.builtin.set_fact:
+    geoip2_local_full_path: "{{ geoip2_local_path + geoip2_local_file }}"
+
+- name: Set the remote database URL
+  ansible.builtin.set_fact:
+    remote_db_url: >-
+      {{
+        geoip2_maxmind_url_format |
+        format(
+          geoip2_maxmind_url_base,
+          geoip2_maxmind_edition,
+          geoip2_maxmind_suffix_file,
+          geoip2_maxmind_license_key
+        )
+      }}
+
+- name: Set the remote checksum URL
+  ansible.builtin.set_fact:
+    remote_checksum_url: >-
+      {{
+        geoip2_maxmind_url_format |
+        format(
+          geoip2_maxmind_url_base,
+          geoip2_maxmind_edition,
+          geoip2_maxmind_suffix_checksum,
+          geoip2_maxmind_license_key
+        )
+      }}
+
+- name: Retrieve the checksum of the latest remote version of the database
+  ansible.builtin.set_fact:
+    latest_version_checksum: "{{ lookup('url', remote_checksum_url) }}"
+
+- name: Create the /usr/local/share/GeoIP/ directory
+  ansible.builtin.file:
+    mode: 0755
+    path: "{{ geoip2_local_path }}"
+    state: directory
+
+- name: Check if the downloaded tar.gz file exists
+  ansible.builtin.stat:
+    path: "{{ geoip2_local_full_path }}"
+    checksum_algorithm: md5
+  register: tarball
+
+- name: Check to see if the remote version is different from the local version
+  ansible.builtin.set_fact:
+    get_update: "{{ True if (not tarball.stat.exists or \
+    tarball.stat.checksum != latest_version_checksum) else False }}"
+
+- name: Download, verify, and extract the latest database version if needed
+  when: get_update
   block:
-    - name: Set the full path for saving the database locally
-      ansible.builtin.set_fact:
-        geoip2_local_full_path: "{{ geoip2_local_path + geoip2_local_file }}"
+    - name: Download GeoIP database and check (md5)
+      ansible.builtin.get_url:
+        url: "{{ remote_db_url }}"
+        mode: 0644
+        dest: "{{ geoip2_local_full_path }}"
+        checksum: "md5:{{ latest_version_checksum }}"
 
-    - name: Set the remote database URL
-      ansible.builtin.set_fact:
-        remote_db_url: >-
-          {{
-            geoip2_maxmind_url_format |
-            format(
-              geoip2_maxmind_url_base,
-              geoip2_maxmind_edition,
-              geoip2_maxmind_suffix_file,
-              geoip2_maxmind_license_key
-            )
-          }}
-
-    - name: Set the remote checksum URL
-      ansible.builtin.set_fact:
-        remote_checksum_url: >-
-          {{
-            geoip2_maxmind_url_format |
-            format(
-              geoip2_maxmind_url_base,
-              geoip2_maxmind_edition,
-              geoip2_maxmind_suffix_checksum,
-              geoip2_maxmind_license_key
-            )
-          }}
-
-    - name: Retrieve the checksum of the latest remote version of the database
-      ansible.builtin.set_fact:
-        latest_version_checksum: "{{ lookup('url', remote_checksum_url) }}"
-
-    - name: Create the /usr/local/share/GeoIP/ directory
-      ansible.builtin.file:
-        mode: 0755
-        path: "{{ geoip2_local_path }}"
-        state: directory
-
-    - name: Check if the downloaded tar.gz file exists
-      ansible.builtin.stat:
-        path: "{{ geoip2_local_full_path }}"
-        checksum_algorithm: md5
-      register: tarball
-
-    - name: Check to see if the remote version is different from the local version
-      ansible.builtin.set_fact:
-        get_update: "{{ True if (not tarball.stat.exists or \
-        tarball.stat.checksum != latest_version_checksum) else False }}"
-
-    - name: Download, verify, and extract the latest database version if needed
-      when: get_update
-      block:
-        - name: Download GeoIP database and check (md5)
-          ansible.builtin.get_url:
-            url: "{{ remote_db_url }}"
-            mode: 0644
-            dest: "{{ geoip2_local_full_path }}"
-            checksum: "md5:{{ latest_version_checksum }}"
-
-        - name: Extract GeoIP database
-          ansible.builtin.unarchive:
-            src: "{{ geoip2_local_full_path }}"
-            dest: "{{ geoip2_local_path }}"
-            remote_src: yes
-            extra_opts:
-              - "--strip-components=1"
+    - name: Extract GeoIP database
+      ansible.builtin.unarchive:
+        src: "{{ geoip2_local_full_path }}"
+        dest: "{{ geoip2_local_path }}"
+        remote_src: yes
+        extra_opts:
+          - "--strip-components=1"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,13 +40,13 @@
   ansible.builtin.set_fact:
     latest_version_checksum: "{{ lookup('url', remote_checksum_url) }}"
 
-- name: Create the /usr/local/share/GeoIP/ directory
+- name: Create the local directory
   ansible.builtin.file:
     mode: 0755
     path: "{{ geoip2_local_path }}"
     state: directory
 
-- name: Check if the downloaded tar.gz file exists
+- name: Check if the local file exists
   ansible.builtin.stat:
     path: "{{ geoip2_local_full_path }}"
     checksum_algorithm: md5

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,8 +48,8 @@
 
 - name: Check if the local file exists
   ansible.builtin.stat:
-    path: "{{ geoip2_local_full_path }}"
     checksum_algorithm: md5
+    path: "{{ geoip2_local_full_path }}"
   register: tarball
 
 - name: Check to see if the remote version is different from the local version
@@ -62,15 +62,15 @@
   block:
     - name: Download GeoIP database and check (md5)
       ansible.builtin.get_url:
-        url: "{{ remote_db_url }}"
-        mode: 0644
-        dest: "{{ geoip2_local_full_path }}"
         checksum: "md5:{{ latest_version_checksum }}"
+        dest: "{{ geoip2_local_full_path }}"
+        mode: 0644
+        url: "{{ remote_db_url }}"
 
     - name: Extract GeoIP database
       ansible.builtin.unarchive:
-        src: "{{ geoip2_local_full_path }}"
         dest: "{{ geoip2_local_path }}"
-        remote_src: yes
         extra_opts:
           - "--strip-components=1"
+        remote_src: yes
+        src: "{{ geoip2_local_full_path }}"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request changes the role's functionality to remove the check of the `maxmind_license_key` variable. It also cleans up some task names to not use specific values when they use variables for those values.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Currently this role will silently "succeed" if no value is provided for the `maxmind_license_key` variable even though we list it as required. This implies that the role has installed the database even if it does nothing which is undesired behavior. The task name changes are just to better reflect the changes occurring and that they use variables.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

### ⚠ Note ###

This will be a breaking change for any role that includes this one as a dependency but does not provide a value for the `maxmind_license_key` variable.

## 🧪 Testing ##

Automated testing passes.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
