### PR TITLE
Support installing multiple database editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,9 @@ None.
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| geoip2\_archive\_filename | The filename to use for the downloaded database archive. | `GeoIP2-City.tar.gz` | No |
 | geoip2\_database\_directory | The directory in which to store the database files. | `/usr/local/share/GeoIP/` | No |
 | geoip2\_maxmind\_account\_id | The MaxMind account ID to use when accessing the MaxMind servers. | n/a | Yes |
-| geoip2\_maxmind\_edition | The database edition to install. | `GeoIP2-City` | No |
+| geoip2\_maxmind\_editions | The list of database editions to install. | `[GeoIP2-City]` | No |
 | geoip2\_maxmind\_license\_key | The MaxMind GeoIP2 license key to use when accessing the MaxMind servers. | n/a | Yes |
 | geoip2\_maxmind\_suffix\_checksum | The suffix of the database checksum file to be downloaded. | `tar.gz.sha256` | No |
 | geoip2\_maxmind\_suffix\_file | The suffix of the database file to be downloaded. | `tar.gz` | No |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-# Name to use for the downloaded database archive
-geoip2_archive_filename: GeoIP2-City.tar.gz
-
 # Directory in which to store GeoIP files
 geoip2_database_directory: /usr/local/share/GeoIP/
 
@@ -9,6 +6,7 @@ geoip2_database_directory: /usr/local/share/GeoIP/
 # https://download.maxmind.com/geoip/databases/<database edition>/download?suffix=tar.gz
 # https://download.maxmind.com/geoip/databases/<database edition>/download?suffix=tar.gz.sha256
 geoip2_maxmind_url_base: https://download.maxmind.com/geoip/databases/%s/download?suffix=%s
-geoip2_maxmind_edition: GeoIP2-City
+geoip2_maxmind_editions:
+  - GeoIP2-City
 geoip2_maxmind_suffix_file: tar.gz
 geoip2_maxmind_suffix_checksum: tar.gz.sha256

--- a/tasks/install_database_edition.yml
+++ b/tasks/install_database_edition.yml
@@ -1,0 +1,72 @@
+---
+- name: Set the full path for saving the database locally
+  ansible.builtin.set_fact:
+    geoip2_archive_full_path: "{{ geoip2_database_directory + database_edition + '.' + geoip2_maxmind_suffix_file }}"
+
+- name: Set the database URL
+  ansible.builtin.set_fact:
+    database_url: >-
+      {{
+        geoip2_maxmind_url_base
+        | format(
+            database_edition,
+            geoip2_maxmind_suffix_file
+          )
+      }}
+
+- name: Set the checksum URL
+  ansible.builtin.set_fact:
+    checksum_url: >-
+      {{
+        geoip2_maxmind_url_base
+        | format(
+            database_edition,
+            geoip2_maxmind_suffix_checksum
+          )
+      }}
+
+# The checksum file is in the format "checksum filename\n"
+- name: Retrieve the checksum of the latest remote version of the database
+  ansible.builtin.set_fact:
+    latest_version_checksum: >-
+      {{
+        lookup(
+          'url',
+          checksum_url,
+          username=geoip2_maxmind_account_id,
+          password=geoip2_maxmind_license_key
+        )
+        | split
+        | first
+      }}
+
+- name: Check if the database archive exists
+  ansible.builtin.stat:
+    checksum_algorithm: sha256
+    path: "{{ geoip2_archive_full_path }}"
+  register: database_archive
+
+- name: Check to see if the remote version is different from the local version
+  ansible.builtin.set_fact:
+    get_update: "{{ True if (not database_archive.stat.exists or \
+    database_archive.stat.checksum != latest_version_checksum) else False }}"
+
+- name: Download, verify, and extract the latest database version if needed
+  when: get_update
+  block:
+    - name: Download the database archive and verify the checksum
+      ansible.builtin.get_url:
+        checksum: sha256:{{ latest_version_checksum }}
+        dest: "{{ geoip2_archive_full_path }}"
+        mode: 0644
+        password: "{{ geoip2_maxmind_license_key }}"
+        url: "{{ database_url }}"
+        username: "{{ geoip2_maxmind_account_id }}"
+
+    - name: Extract the database file
+      ansible.builtin.unarchive:
+        dest: "{{ geoip2_database_directory }}"
+        extra_opts:
+          - --strip-components=1
+        remote_src: true
+        src: "{{ geoip2_archive_full_path }}"

--- a/tasks/install_database_edition.yml
+++ b/tasks/install_database_edition.yml
@@ -1,7 +1,15 @@
 ---
 - name: Set the full path for saving the database locally
   ansible.builtin.set_fact:
-    geoip2_archive_full_path: "{{ geoip2_database_directory + database_edition + '.' + geoip2_maxmind_suffix_file }}"
+    geoip2_archive_full_path: >-
+      {{
+        "%s/%s.%s"
+        | format(
+            geoip2_database_directory,
+            database_edition,
+            geoip2_maxmind_suffix_file
+          )
+      }}
 
 - name: Set the database URL
   ansible.builtin.set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,80 +12,14 @@
       - gzip
       - tar
 
-- name: Set the full path for saving the database locally
-  ansible.builtin.set_fact:
-    geoip2_archive_full_path: "{{ geoip2_database_directory + geoip2_archive_filename }}"
-
-- name: Set the database URL
-  ansible.builtin.set_fact:
-    database_url: >-
-      {{
-        geoip2_maxmind_url_base
-        | format(
-            geoip2_maxmind_edition,
-            geoip2_maxmind_suffix_file
-          )
-      }}
-
-- name: Set the checksum URL
-  ansible.builtin.set_fact:
-    checksum_url: >-
-      {{
-        geoip2_maxmind_url_base
-        | format(
-            geoip2_maxmind_edition,
-            geoip2_maxmind_suffix_checksum
-          )
-      }}
-
-# The checksum file is in the format "checksum filename\n"
-- name: Retrieve the checksum of the latest remote version of the database
-  ansible.builtin.set_fact:
-    latest_version_checksum: >-
-      {{
-        lookup(
-          'url',
-          checksum_url,
-          username=geoip2_maxmind_account_id,
-          password=geoip2_maxmind_license_key
-        )
-        | split
-        | first
-      }}
-
 - name: Ensure the directory in which to store the database file exists
   ansible.builtin.file:
     mode: 0755
     path: "{{ geoip2_database_directory }}"
     state: directory
 
-- name: Check if the database archive exists
-  ansible.builtin.stat:
-    checksum_algorithm: sha256
-    path: "{{ geoip2_archive_full_path }}"
-  register: database_archive
-
-- name: Check to see if the remote version is different from the local version
-  ansible.builtin.set_fact:
-    get_update: "{{ True if (not database_archive.stat.exists or \
-    database_archive.stat.checksum != latest_version_checksum) else False }}"
-
-- name: Download, verify, and extract the latest database version if needed
-  when: get_update
-  block:
-    - name: Download the database archive and verify the checksum
-      ansible.builtin.get_url:
-        checksum: sha256:{{ latest_version_checksum }}
-        dest: "{{ geoip2_archive_full_path }}"
-        mode: 0644
-        password: "{{ geoip2_maxmind_license_key }}"
-        url: "{{ database_url }}"
-        username: "{{ geoip2_maxmind_account_id }}"
-
-    - name: Extract the database file
-      ansible.builtin.unarchive:
-        dest: "{{ geoip2_database_directory }}"
-        extra_opts:
-          - --strip-components=1
-        remote_src: true
-        src: "{{ geoip2_archive_full_path }}"
+- name: Install the specified MaxMind database edition
+  ansible.builtin.include_tasks: install_database_edition.yml
+  loop: "{{ geoip2_maxmind_editions }}"
+  loop_control:
+    loop_var: database_edition


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the role to support installing multiple editions of the MaxMind GeoIP2 databases at once.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Although we generally only care about the `City` edition, there are at least five editions available for MaxMind's GeoIP2 databases. Therefore, it would be convenient to install all of the desired editions with one use of this role (as long as they share a destination directory).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
